### PR TITLE
Description of the Exmouth-Gulf setup in the documentation

### DIFF
--- a/web/content/de/_index.html
+++ b/web/content/de/_index.html
@@ -28,13 +28,3 @@ Describing belowground competition based on first principles
 
 Bathmann, J., Peters, R., Naumov, D., Fischer, T., Berger, U., Walther, M., 2020. The MANgrove–GroundwAter feedback model (MANGA) – Describing belowground competition based on first principles. Ecological Modelling 11.
 {{< /blocks/section >}}
-
-{{< blocks/section color="white" >}}
-
-<div style="display: table; width: 100%;">
-<figure style="display: table-cell; padding: 0 4px; text-align: center;"><a href="https://tu-dresden.de/"><img src="Logo_TU.png"  height="50px" width="auto"></a></figure>
-<figure style="display: table-cell; padding: 0 4px; text-align: center;"><a href="https://www.ufz.de/"><img src="Logo_UFZ.png"  height="50px" width="auto"></a></figure>
-</div>
-
-
-{{< /blocks/section >}}


### PR DESCRIPTION
First an Error correction:

Removal of the duplication of the logos of the TU and UFZ
on the German homepage