### PR TITLE
Bugfix ogs

### DIFF
--- a/TreeModelLib/BelowgroundCompetition/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.py
+++ b/TreeModelLib/BelowgroundCompetition/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.py
@@ -113,7 +113,7 @@ class NetworkOGSLargeScale3D(SimpleNetwork, OGSLargeScale3D):
         self.belowground_resources = SimpleNetwork.getBGfactor(self)
 
         # Update network parameters
-        super().updateNetworkParametersForGrowthAndDeath(self)
+        super().updateNetworkParametersForGrowthAndDeath()
 
         # OGS stuff - update ogs parameters
         self.renameParameters()

--- a/TreeModelLib/BelowgroundCompetition/OGSLargeScale3D/python_source.py
+++ b/TreeModelLib/BelowgroundCompetition/OGSLargeScale3D/python_source.py
@@ -111,19 +111,15 @@ class FluxToTrees(OpenGeoSys.SourceTerm):
         return (-positive_flux, Jac)
 
 
-constant_contributions = np.load(
-    "test/LargeTests/Test_Setups_large/ogs_example_setup/constant_contributions.npy"
-)
-salinity_prefactors = np.load(
-    "test/LargeTests/Test_Setups_large/ogs_example_setup/salinity_prefactors.npy"
-)
+constant_contributions = np.load("constant_contributions.npy")
+salinity_prefactors = np.load("salinity_prefactors.npy")
 cumsum_salinity = np.zeros_like(salinity_prefactors)
 calls = np.zeros_like(salinity_prefactors)
 counter = np.zeros((1), dtype=int)
 max_calls = np.zeros_like(constant_contributions)
 
-cumsum_savename = "test/LargeTests/Test_Setups_large/ogs_example_setup/cumsum_salinity.npy"
-calls_savename = "test/LargeTests/Test_Setups_large/ogs_example_setup/calls_in_last_timestep.npy"
+cumsum_savename = "cumsum_salinity.npy"
+calls_savename = "calls_in_last_timestep.npy"
 
 t_write = t_end
 cell_information = CellInformation(source_mesh)

--- a/test/LargeTests/Test_Setups_large/ogs_example_setup/NetwOGS3D_SAZOI_BETTINA.xml
+++ b/test/LargeTests/Test_Setups_large/ogs_example_setup/NetwOGS3D_SAZOI_BETTINA.xml
@@ -20,7 +20,7 @@
             <ogs_project_file>testmodel.prj</ogs_project_file>
             <source_mesh>source_domain.vtu</source_mesh>
             <bulk_mesh>testbulk.vtu</bulk_mesh>
-            <delta_t_ogs>86400</delta_t_ogs> <!--24 h wie in testmodel.rpj -->
+            <delta_t_ogs>86400</delta_t_ogs>
             <abiotic_drivers>
                 <seaward_salinity>0.035</seaward_salinity>
             </abiotic_drivers>


### PR DESCRIPTION
With the changes proposed here, OGS in combination with the Simple and Network modules is working for me (on windows).
Main changes are:

- remove comments from xml file (caused trouble with the functions that finds missing tags in SimpleNetwork, no problem with tag reading in OGSLargeSc...)
- bugfix in NetworkOGS with parent-call
-  removed paths in python_source -> if paths are provided in this file, e.g. for 'cumsum_savename', the new path is appended and those the new files can not be found -> @jbathmann : can you please test if this still works for you (using OGS3D_SAZOI_BETTINA.xml)