### PR TITLE
Partner Queue Solution for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+os: linux
+arch:
+    - arm64
+    - ppc64le
+    - s390x
 # This will run on Travis' 'new' container-based infrastructure
 sudo: false 
 


### PR DESCRIPTION
As mentioned in #159, travis ci was not syncing.

This PR closes #159, as it adds a new free solution which allows to trigger builds for free.