### PR TITLE
Write output in last time step

### DIFF
--- a/TimeLoopLib/TreeDynamicTimeStepping.py
+++ b/TimeLoopLib/TreeDynamicTimeStepping.py
@@ -83,7 +83,7 @@ class TreeDynamicTimeStepping:
                         tree_group)
                     self.tree_output.writeOutput(eliminated_tree_groups,
                                                  t_start,
-                                                 force_outpu=True)
+                                                 force_output=True)
 
             tree_group.removeTreesAtIndices(kill_indices)
             tree_group.recruitTrees()
@@ -103,7 +103,7 @@ class TreeDynamicTimeStepping:
         tree_groups = self.population.getTreeGroups()
         # Write output in last time step, even if not defined in the project
         # file
-        self.tree_output.writeOutput(tree_groups, time, force_outpu=True)
+        self.tree_output.writeOutput(tree_groups, time, force_output=True)
 
     def setResources(self, ag_resources, bg_resources):
         self.aboveground_resources = ag_resources

--- a/TimeLoopLib/TreeDynamicTimeStepping.py
+++ b/TimeLoopLib/TreeDynamicTimeStepping.py
@@ -83,7 +83,7 @@ class TreeDynamicTimeStepping:
                         tree_group)
                     self.tree_output.writeOutput(eliminated_tree_groups,
                                                  t_start,
-                                                 it_is_last_ts=True)
+                                                 force_outpu=True)
 
             tree_group.removeTreesAtIndices(kill_indices)
             tree_group.recruitTrees()
@@ -103,7 +103,7 @@ class TreeDynamicTimeStepping:
         tree_groups = self.population.getTreeGroups()
         # Write output in last time step, even if not defined in the project
         # file
-        self.tree_output.writeOutput(tree_groups, time, it_is_last_ts=True)
+        self.tree_output.writeOutput(tree_groups, time, force_outpu=True)
 
     def setResources(self, ag_resources, bg_resources):
         self.aboveground_resources = ag_resources

--- a/TreeOutputLib/TreeOutput.py
+++ b/TreeOutputLib/TreeOutput.py
@@ -138,14 +138,14 @@ class TreeOutput:
     #  For each timestep a file is created throughout the simulation.
     #  This function is only able to work, if the output directory exists and
     #  is empty at the begin of the model run
-    def writeOutput(self, tree_groups, time, force_outpu=False):
+    def writeOutput(self, tree_groups, time, force_output=False):
         if self.output_each_nth_timestep is not None:
             self._output_counter = (self._output_counter %
                                     self.output_each_nth_timestep)
             self._it_is_output_time = (self._output_counter == 0)
         if self.output_times is not None:
             self._it_is_output_time = (time in self.output_times)
-        if force_outpu:
+        if force_output:
             self._it_is_output_time = True
 
         if self._it_is_output_time:

--- a/TreeOutputLib/TreeOutput.py
+++ b/TreeOutputLib/TreeOutput.py
@@ -138,14 +138,14 @@ class TreeOutput:
     #  For each timestep a file is created throughout the simulation.
     #  This function is only able to work, if the output directory exists and
     #  is empty at the begin of the model run
-    def writeOutput(self, tree_groups, time, it_is_last_ts=False):
+    def writeOutput(self, tree_groups, time, force_outpu=False):
         if self.output_each_nth_timestep is not None:
             self._output_counter = (self._output_counter %
                                     self.output_each_nth_timestep)
             self._it_is_output_time = (self._output_counter == 0)
         if self.output_times is not None:
             self._it_is_output_time = (time in self.output_times)
-        if it_is_last_ts:
+        if force_outpu:
             self._it_is_output_time = True
 
         if self._it_is_output_time:

--- a/TreeOutputLib/TreeOutput.py
+++ b/TreeOutputLib/TreeOutput.py
@@ -138,13 +138,15 @@ class TreeOutput:
     #  For each timestep a file is created throughout the simulation.
     #  This function is only able to work, if the output directory exists and
     #  is empty at the begin of the model run
-    def writeOutput(self, tree_groups, time):
+    def writeOutput(self, tree_groups, time, it_is_last_ts=False):
         if self.output_each_nth_timestep is not None:
             self._output_counter = (self._output_counter %
                                     self.output_each_nth_timestep)
             self._it_is_output_time = (self._output_counter == 0)
         if self.output_times is not None:
             self._it_is_output_time = (time in self.output_times)
+        if it_is_last_ts:
+            self._it_is_output_time = True
 
         if self._it_is_output_time:
             self.outputContent(tree_groups, time)


### PR DESCRIPTION
Small change to write output after last time step (in case all trees died).
Imho, it's a required feature to benchmark mortality concepts  effeciently.

Just realized that it doesn't work... @jbathmann do you have an idea how to implement this?